### PR TITLE
some bug fixes

### DIFF
--- a/examples/example_stdlib.zig
+++ b/examples/example_stdlib.zig
@@ -183,9 +183,9 @@ fn respondJson(arena: std.mem.Allocator, request: *std.http.Server.Request, valu
             },
         },
     });
-    defer body.end() catch {};
     const jf = std.json.fmt(value, .{});
     try jf.format(&body.writer);
+    try body.end();
 }
 
 // ----- Handlers -----
@@ -334,7 +334,6 @@ fn svgMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void {
 
     var body_buffer: [4096]u8 = undefined;
     var body = try beginStream(&body_buffer, request);
-    defer body.end() catch {};
 
     var frame_buf: [4096]u8 = undefined;
     var fba: std.heap.FixedBufferAllocator = .init(&frame_buf);
@@ -359,6 +358,8 @@ fn svgMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void {
         });
         try shared_io.sleep(.fromMilliseconds(100), .real);
     }
+
+    try body.end();
 }
 
 fn emitSvgFrame(body: *std.http.BodyWriter, fba: *std.heap.FixedBufferAllocator, comptime fmt: []const u8, args: anytype) !void {
@@ -393,7 +394,6 @@ fn mathMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void 
 
     var stream_buffer: [4096]u8 = undefined;
     var stream = try beginStream(&stream_buffer, request);
-    defer stream.end() catch {};
 
     var frame_buf: [4096]u8 = undefined;
     var fba: std.heap.FixedBufferAllocator = .init(&frame_buf);
@@ -418,8 +418,7 @@ fn mathMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void 
     fba.reset();
     const reset_block = try datastar.patchSignals(fba.allocator(), .{ .mathmlMorph = 1 }, .{});
     try stream.writer.writeAll(reset_block);
-    try stream.writer.flush();
-    try stream.flush();
+    try stream.end();
 }
 
 const snippets = [_][]const u8{
@@ -472,7 +471,6 @@ fn mimeTest(arena: std.mem.Allocator, request: *std.http.Server.Request, filenam
 fn hotreload(request: *std.http.Server.Request, id: u64) !void {
     var stream_buffer: [4096]u8 = undefined;
     var stream = try beginStream(&stream_buffer, request);
-    defer stream.end() catch {};
 
     var frame_buf: [1024]u8 = undefined;
     var fba: std.heap.FixedBufferAllocator = .init(&frame_buf);
@@ -500,4 +498,6 @@ fn hotreload(request: *std.http.Server.Request, id: u64) !void {
         try stream.writer.flush();
         try stream.flush();
     }
+
+    try stream.end();
 }

--- a/examples/example_stdlib.zig
+++ b/examples/example_stdlib.zig
@@ -316,9 +316,8 @@ fn executeScript(arena: std.mem.Allocator, request: *std.http.Server.Request, sa
 
 // ----- Long-lived streaming SSE -----
 
-fn beginStream(request: *std.http.Server.Request) !std.http.BodyWriter {
-    var buf: [4096]u8 = undefined;
-    var body = try request.respondStreaming(&buf, .{
+fn beginStream(buffer: []u8, request: *std.http.Server.Request) !std.http.BodyWriter {
+    var body = try request.respondStreaming(buffer, .{
         .respond_options = .{
             .extra_headers = &.{
                 .{ .name = "content-type", .value = "text/event-stream; charset=UTF-8" },
@@ -333,7 +332,8 @@ fn beginStream(request: *std.http.Server.Request) !std.http.BodyWriter {
 fn svgMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void {
     const opt = try datastar.readSignals(struct { svgMorph: usize = 1 }, arena, request);
 
-    var body = try beginStream(request);
+    var body_buffer: [4096]u8 = undefined;
+    var body = try beginStream(&body_buffer, request);
     defer body.end() catch {};
 
     var frame_buf: [4096]u8 = undefined;
@@ -391,7 +391,8 @@ fn mathMorph(arena: std.mem.Allocator, request: *std.http.Server.Request) !void 
         return;
     }
 
-    var stream = try beginStream(request);
+    var stream_buffer: [4096]u8 = undefined;
+    var stream = try beginStream(&stream_buffer, request);
     defer stream.end() catch {};
 
     var frame_buf: [4096]u8 = undefined;
@@ -469,7 +470,8 @@ fn mimeTest(arena: std.mem.Allocator, request: *std.http.Server.Request, filenam
 }
 
 fn hotreload(request: *std.http.Server.Request, id: u64) !void {
-    var stream = try beginStream(request);
+    var stream_buffer: [4096]u8 = undefined;
+    var stream = try beginStream(&stream_buffer, request);
     defer stream.end() catch {};
 
     var frame_buf: [1024]u8 = undefined;

--- a/hello_world/main.zig
+++ b/hello_world/main.zig
@@ -101,7 +101,6 @@ fn streamHello(io: Io, arena: std.mem.Allocator, request: *std.http.Server.Reque
             },
         },
     });
-    defer body.end() catch {};
     try body.flush(); // push headers to the wire before first SSE event
 
     for (0..MESSAGE.len) |i| {
@@ -118,4 +117,5 @@ fn streamHello(io: Io, arena: std.mem.Allocator, request: *std.http.Server.Reque
         }
     }
     std.debug.print("\n", .{});
+    try body.end();
 }


### PR DESCRIPTION
`beginStream` function in example_stdlib.zig was returning pointer to a stack variable.

using `BodyWriter.end()` in defer is just incorrect. It swallows the error which may happen in end() (it would for example prevent Cancelation from working) and it also writes to the buffer even tho presense of error indicates what its no longer possible to write to the buffer. [more discussion about it](https://ziggit.dev/t/i-know-its-wrong-to-use-defer-like-this-but-i-cant-resist-the-temptation-to-use-it/12987)